### PR TITLE
[ENHANCEMENT] Invert tests inclusion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 > Example usage
 
 ```
-nix run github:Sigmapitech/cs . --ignore-tests --ignore-rules=C-G1,C-O3
+nix run github:Sigmapitech/cs . --include-tests --ignore-rules=C-G1,C-O3
 ```

--- a/report.py
+++ b/report.py
@@ -98,7 +98,7 @@ def main() -> int:
     marker = time.perf_counter()
     count = run_vera(
         vera, ruleset, project_dir,
-        ignore_tests="--ignore-tests" in args,
+        ignore_tests="--include-tests" not in args,
         ignored_rules=ignored_rules
     )
 


### PR DESCRIPTION
Change the behaviour from a opt-out to a opt-in option.
Now you need to specify the `--include-tests` option to run in the tests folder